### PR TITLE
Remove encodeURI in RequestManager for compare urls

### DIFF
--- a/lib/assets/javascripts/_request_manager.js.coffee
+++ b/lib/assets/javascripts/_request_manager.js.coffee
@@ -33,7 +33,7 @@ class RequestManager
         else
           state = History.getState()
 
-          if url? && (url != encodeURI(self._normalize(state.url)))
+          if url? && (url != self._normalize(state.url))
             self._redirect_to(url, $target, state, xhr)
 
           $target.html(data)


### PR DESCRIPTION
Hello!

i found some bug.

``` ruby
encodeURI(url) != url
```
