### PR TITLE
fixed IE10 damn port comparison

### DIFF
--- a/lib/assets/javascripts/_link.js.coffee
+++ b/lib/assets/javascripts/_link.js.coffee
@@ -17,8 +17,18 @@ class Link
   #
   _cross_origin_link: (link) ->
     (location.protocol != link.protocol) ||
-    (location.port != link.port) ||
+    (!_compare_link_port_with_location_port(link)) ||
     (location.host.split(':')[0] != link.host.split(':')[0])
+
+  #
+  # private method for port comparison
+  # IE10 returns for link.port "80" but the location.port is ""
+  # stupid but "modern" browsers returning the same values
+  #
+  _compare_link_port_with_location_port = (link) ->
+    (location.port == link.port) ||
+    (location.port == "" && link.port == "80")
+
 
   _non_standard_click: (event) ->
     event.metaKey || event.ctrlKey || event.shiftKey || event.altKey


### PR DESCRIPTION
Hi @igor-alexandrov, 

I found a bug :bug:, it took some time to find out why IE is not working correctly with wiselinks. I guess the source is more or less self explaining. It´s difficult to write tests, in this case I tried it on my VM with IE10. With Chrome, Safari and Firefox. 

To reproduce, use browserstack.com or what else to get an IE and try your example page. It is not using ajax to get content.

Have a nice weekend and with best regards. :+1: 
