### PR TITLE
request_manager module erroring out on wiselinks events as $target was t...

### DIFF
--- a/lib/assets/javascripts/_request_manager.js.coffee
+++ b/lib/assets/javascripts/_request_manager.js.coffee
@@ -34,8 +34,10 @@ class RequestManager
           state = History.getState()
           if url? && (url != self._normalize(state.url))
             self._redirect_to(url, $target, state, xhr)
-
-          $target.html(data)
+          if $target instanceof jQuery
+            $target.html(data)
+          else
+            $($target).html(data)
 
           self._title(xhr.getResponseHeader('X-Wiselinks-Title'))
           self._done($target, status, state, data)


### PR DESCRIPTION
We are using wiselinks in a Rails 4 App, in which we use backbone for js code organization, with minimal use of backbone models for some funky menus implemented on our site.

In trying to get this working with our app we have one complicated menu that implements a search and sets the required search url in a model - here is the code where we call wiselinks - as we dont actually implement a link:

  resetItems: ->
    window.wiselinks.load(@model.get('search_url'),'#wise-container',"template")

we have set wiselinks events in our view initialize as follows:

initialize: -> 
....
    @target = '#wise-container'
    @wrender =  'template'
    window.wiselinks = new Wiselinks(@target)
    $(document).off('page:loading').on 'page:loading', (event, @target, @wrender, url) =>
      $('[data-pjax-container]').animate
        opacity: '0.2'
      ,500
      if $.getUrlVar('list')?
        $("html, body").animate
          scrollTop: 0
        , 300
    $(document).off('page:always').on 'page:always', (event, xhr, settings) =>
      $('[data-pjax-container]').animate
        opacity: '1.0'
      ,300
      #unless (@list_view or !!@isotope_id) ---> ORGINAL CODE, changed as creates a bug on changing destinations on places page
      if @isotope_id? &&  !$(@isotope_id).hasClass('isotope')
        $.initIsotope(@isotope_id, @item_selector)
      $.toolTipApply()
    $(document).off('page:done').on 'page:done', (event, $target, status, url, data) =>
      @model.set('dest_categories', window.menucategories)
    @model.on "change:view_params", @render, this

On the done event we kept getting errors $target has no method HTML in request manager, not sure exactly the reason for this (maybe backbone), when debugging we noted the $target was only the string value of the target div, hence implemented the following as a fix. All other aspects of wiselinks are working correctly - and we were able to fix this error by implementing this code. Not sure whether we are doing something wrong - but you may want to pull in this inocuous fix. If we are doing something wrong in our wiselinks implementation your feedback would be much appreciated. (N/B. ignore the naming of pjax-container, we replaced pjax here with wizelinks but didnt rename that particular container).

Great plugin so far! thanks for the contribution!
