### PR TITLE
Fixed problem with form actions that contain query string params

### DIFF
--- a/lib/assets/javascripts/_form.js.coffee
+++ b/lib/assets/javascripts/_form.js.coffee
@@ -66,7 +66,7 @@ class Form
     else
       @$form.serialize()
 
-    url = @$form.attr("action")
+    url = @$form.attr("action").replace(/\?.*$/, '')
     url += "?#{serialized}" if serialized.length > 0
     url
 


### PR DESCRIPTION
If the action attribute of some form contains query string params (e.g. /books?locale=en), the url returned by the _url method looks like this: /books?locale=en?<serialized_form>. The solution is to remove query string params from this attribute.
