### PR TITLE
Fix the data passed in page:done event

### DIFF
--- a/lib/assets/javascripts/_request_manager.js.coffee
+++ b/lib/assets/javascripts/_request_manager.js.coffee
@@ -85,7 +85,7 @@ class RequestManager
           @_robots(response.robots())
           @_link_rel_prev(response.link_rel_prev())
           @_link_rel_next(response.link_rel_next())
-          @_done($target, status, state, response.content())
+          @_done($target, status, state, data)
       )
 
   _fail: ($target, status, state, error, code, data) ->


### PR DESCRIPTION
https://github.com/igor-alexandrov/wiselinks/pull/62 breaks what the [readme](https://github.com/igor-alexandrov/wiselinks#javascript-events) says about `data`:

```
page:done ($target, status, url, data)

Event is triggered if the request succeeds.

    $target – jQuery object that was updated with the request;

    status – a string describing the status;

    url – url of the request;

    data – content of the request;
```

Now it always passes the target DOM, but I expect a full document when it is returned by request from server/browser cache to do some custom update
