### PR TITLE
forcePartial option

### DIFF
--- a/lib/assets/javascripts/_request_manager.js.coffee
+++ b/lib/assets/javascripts/_request_manager.js.coffee
@@ -65,7 +65,8 @@ class RequestManager
     )
 
   _html_loaded: ($target, data, status, xhr) ->
-    response = new window._Wiselinks.Response(data, xhr, $target)
+    forcePartial = @options.forcePartial || false
+    response = new window._Wiselinks.Response(data, xhr, $target, forcePartial)
 
     url = @_normalize(response.url())
     assets_digest = response.assets_digest()

--- a/lib/assets/javascripts/_response.js.coffee
+++ b/lib/assets/javascripts/_response.js.coffee
@@ -10,7 +10,7 @@ class Response
     Response._document_parser ?= new window._Wiselinks.DOMParser
 
 
-  constructor: (@html, @xhr, @$target) ->
+  constructor: (@html, @xhr, @$target, @forcePartial = false) ->
 
   url: ->
     @xhr.getResponseHeader('X-Wiselinks-Url')
@@ -87,7 +87,7 @@ class Response
       @html
 
   _is_full_document_response: ->
-    @_get_doc_target_node().length is 1
+    @_get_doc_target_node().length is 1 && !@forcePartial
 
   _get_doc_target_node: ->
     @$doc_target_node ?= $(@$target.selector, @_get_doc())


### PR DESCRIPTION
Add option to avoid wiselinks interpreting the response as a Full Document Response when having only one target.

When enabled the following headers will be always used (even if the target is 1 element):
- X-Wiselinks-Assets-Digest
- X-Wiselinks-Title
- X-Wiselinks-Description
- X-Wiselinks-Canonical
- X-Wiselinks-Robots
- X-Wiselinks-LinkRelPrev
- X-Wiselinks-LinkRelNext
