### PR TITLE
README: Add page navigation via JS section

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,10 @@ Wiselinks handles page titles by passing `X-Wiselinks-Title` header with respons
 
 Of course you can use `wiselinks_title` helper in your own helpers too.
 
+### Invoking a page navigation via Javascript
+
+You can use `wiselinks.page.load(path)` to go to a URL through Wiselinks.
+
 ### Redirect handling
 
 Wiselinks follows 30x HTTP redirects. Location is updated in browser with `X-Wiselinks-Url` header that is setting up automatically (in Rails) on every wiselinks request.


### PR DESCRIPTION
Turbolinks has a section on navigating using `Turbolinks.visit(path)`. I use this in my code and had to dig into the source to figure out how to do this in Wiselinks. Adding documentation to clarify how to do this.
