### PR TITLE
Properly set title

### DIFF
--- a/lib/assets/javascripts/_response.js.coffee
+++ b/lib/assets/javascripts/_response.js.coffee
@@ -28,10 +28,8 @@ class Response
     @_title ?= @_extract_title()
 
   _extract_title: ->
-    if @_is_full_document_response()
-      $('title', @_get_doc()).text()
-    else
-      @xhr.getResponseHeader('X-Wiselinks-Title')
+    title_header = decodeURIComponent @xhr.getResponseHeader 'X-Wiselinks-Title'
+    $("<p>").html(title_header).text() || $('title', @_get_doc()).text()
 
   description: ->
     @_description ?= @_extract_description()


### PR DESCRIPTION
Partially resolves #81 (`X-Wiselinks-Title` header only).

This works for me. I'm not sure if the `||` condition is getting called in my case so I'd like someone to test that.

Also, HTML entities (e.g. `&amp;` or `&#39;`) need to be decoded. Neither Javascript, jQuery or Underscore provide a clean way to do this.

Vanilla JS (coffee): `str.replace /&#(\d+);/g, (_,d) -> String.fromCharCode(d))`
jQuery: `$('<p>').html(str).text()` (what I used)
Underscore: `_.unescape str` (only works on 5 common entities but not `&#39;`)
