### PR TITLE
Prevent exception when cookies disabled

### DIFF
--- a/lib/assets/javascripts/lib/native.history.js
+++ b/lib/assets/javascripts/lib/native.history.js
@@ -1307,7 +1307,7 @@ if (typeof JSON !== 'object') {
 		console = window.console||undefined, // Prevent a JSLint complain
 		document = window.document, // Make sure we are using the correct document
 		navigator = window.navigator, // Make sure we are using the correct navigator
-		sessionStorage = window.sessionStorage||false, // sessionStorage
+		sessionStorage = false, // sessionStorage
 		setTimeout = window.setTimeout,
 		clearTimeout = window.clearTimeout,
 		setInterval = window.setInterval,
@@ -1318,6 +1318,7 @@ if (typeof JSON !== 'object') {
 		history = window.history; // Old History Object
 
 	try {
+        sessionStorage = window.sessionStorage;
 		sessionStorage.setItem('TEST', '1');
 		sessionStorage.removeItem('TEST');
 	} catch(e) {

--- a/wiselinks.gemspec
+++ b/wiselinks.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
 
-  gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'webmock', '~> 1.9.0'
   gem.add_development_dependency 'shoulda'
   gem.add_development_dependency 'simplecov'


### PR DESCRIPTION
This is the same fix as seen [here](https://github.com/browserstate/history.js/commit/0895348d1c8bfcbf6cda3d18ac607beded17bf57). Wiselinks does not work with cookies disabled (tested in Chrome).

Oh and I removed that duplicate `rspec` from the Gemspec. Actually threw an exception when installing my forked repository via bundler.